### PR TITLE
Support for spatie/laravel-backup v7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^7.3|^8.0",
         "ext-zip": "^1.14.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "spatie/laravel-backup": "~6.0"
+        "spatie/laravel-backup": "~6.0|~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0|^9.0",


### PR DESCRIPTION
V7 of `spatie/laravel-backup` has been released on December, 16th. The only major change mentioned in the [upgrade guide](https://github.com/spatie/laravel-backup/blob/master/UPGRADING.md) is that the notification classes are now suffixed with `Notification`. This package does not seem to make use of that. All tests pass with the new version.

Wasn't sure whether to target `master` or `dev`.